### PR TITLE
fix: stop unbind() from falsely reporting NoPermission after every call

### DIFF
--- a/app/src/main/kotlin/dev/lyo/callrec/recorder/ShizukuClient.kt
+++ b/app/src/main/kotlin/dev/lyo/callrec/recorder/ShizukuClient.kt
@@ -142,7 +142,15 @@ class ShizukuClient(private val ctx: Context) {
 
     fun unbind(remove: Boolean = false) {
         runCatching { Shizuku.unbindUserService(args, conn, remove) }
-        _health.value = if (Shizuku.pingBinder()) DaemonHealth.NoPermission else DaemonHealth.NotRunning
+        // Voluntarily dropping our own binding doesn't mean permission was
+        // revoked — re-check checkSelfPermission() instead of assuming
+        // NoPermission, or every call-end falsely re-triggers the
+        // "permission needed" notification/onboarding prompt.
+        _health.value = when {
+            !Shizuku.pingBinder() -> DaemonHealth.NotRunning
+            Shizuku.checkSelfPermission() != PackageManager.PERMISSION_GRANTED -> DaemonHealth.NoPermission
+            else -> DaemonHealth.NotRunning
+        }
     }
 
     fun refresh() = recompute()


### PR DESCRIPTION
Fixes #13.

## Root cause

`ShizukuClient.unbind()` set `DaemonHealth.NoPermission` whenever `Shizuku.pingBinder()` was still true, without ever calling `Shizuku.checkSelfPermission()`:

```kotlin
fun unbind(remove: Boolean = false) {
    runCatching { Shizuku.unbindUserService(args, conn, remove) }
    _health.value = if (Shizuku.pingBinder()) DaemonHealth.NoPermission else DaemonHealth.NotRunning
}
```

`unbind()` runs unconditionally at the end of every call, from `CallMonitorService.onDestroy()`. At that point Shizuku's own binder (`pingBinder()`) is almost always still alive — only our own recorder `UserService` connection was just torn down — so this branch fired deterministically after every single recording, regardless of whether the actual Shizuku permission grant had changed at all.

That mislabeled `NoPermission` state then fanned out into user-visible symptoms:
- `App.kt` observes `ShizukuClient.health` and posts a "cally: permission needed" notification for `NoPermission`.
- If the app is resumed, the Onboarding flow force-navigates back and shows a "permission denied, grant manually" banner.

Both fired after every call even though permission was never actually revoked — matching the reported behavior exactly.

## Fix

`unbind()` now re-checks `Shizuku.checkSelfPermission()` (same as `recompute()` already does elsewhere) instead of inferring permission loss from binder aliveness alone:

```kotlin
fun unbind(remove: Boolean = false) {
    runCatching { Shizuku.unbindUserService(args, conn, remove) }
    _health.value = when {
        !Shizuku.pingBinder() -> DaemonHealth.NotRunning
        Shizuku.checkSelfPermission() != PackageManager.PERMISSION_GRANTED -> DaemonHealth.NoPermission
        else -> DaemonHealth.NotRunning
    }
}
```

## Testing

- `./gradlew :app:compileDebugKotlin` succeeds.
- Not yet verified on-device against the exact repro in #13 (recording a real call end-to-end); logic change is narrowly scoped to the health-derivation branch identified above.